### PR TITLE
bugfix: ansible crashes if no modules are specified in config file

### DIFF
--- a/ansible/roles/vectoria/tasks/download_LLMs.yml
+++ b/ansible/roles/vectoria/tasks/download_LLMs.yml
@@ -5,25 +5,31 @@
 
 - name: Download embedder model
   shell: |
+    {% if git_lfs_modules %}
     {% for module in git_lfs_modules %}
     module load {{ module }}
     {% endfor %}
+    {% endif %}
     git-lfs install
     git clone git@hf.co:{{ embedder_model }} {{ install_path }}/embedder_model
 
 - name: Download reranker model
   shell: |
+    {% if git_lfs_modules %}
     {% for module in git_lfs_modules %}
     module load {{ module }}
     {% endfor %}
+    {% endif %}
     git-lfs install
     git clone git@hf.co:{{ reranker_model }} {{ install_path }}/reranker_model
   when: reranker_enabled
 
 - name: Download inference engine
   shell: |
+    {% if git_lfs_modules %}
     {% for module in git_lfs_modules %}
     module load {{ module }}
     {% endfor %}
+    {% endif %}
     git-lfs install
     git clone git@hf.co:{{ inference_engine }} {{ install_path }}/inference_engine

--- a/ansible/roles/vectoria/tasks/install_vectoria.yml
+++ b/ansible/roles/vectoria/tasks/install_vectoria.yml
@@ -16,9 +16,11 @@
 
 - name: Install Vectoria on HPC
   shell: |
+    {% if hpc_modules %}
     {% for module in hpc_modules %}
     module load {{ module }}
     {% endfor %}
+    {% endif %}
     python -m venv {{ install_path }}/vectoria_env --system-site-packages
     source {{ install_path }}/vectoria_env/bin/activate
     pip install -e {{ install_path }}/vectoria

--- a/ansible/roles/vectoria/templates/setup_vectoria.j2
+++ b/ansible/roles/vectoria/templates/setup_vectoria.j2
@@ -1,7 +1,9 @@
+{% if hpc_modules %}
 {% for module in hpc_modules %}
 module load {{ module }}
 {% endfor %}
 echo "All modules loaded..."
+{% endif %}
 
 source {{ install_path }}/vectoria_env/bin/activate
 echo "Environment loaded..."

--- a/ansible/roles/vectoria/templates/start_build_index.j2
+++ b/ansible/roles/vectoria/templates/start_build_index.j2
@@ -17,9 +17,12 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # Avoid fragmentation
 export TMPDIR={{ tmpdir }}
 export TMP={{ tmpdir }}
 
+{% if hpc_modules %}
 {% for module in hpc_modules %}
 module load {{ module }}
 {% endfor %}
+echo "All modules loaded..."
+{% endif %}
 echo "All modules loaded..."
 
 source {{ install_path }}/vectoria_env/bin/activate

--- a/ansible/roles/vectoria/templates/start_inference.j2
+++ b/ansible/roles/vectoria/templates/start_inference.j2
@@ -51,9 +51,12 @@ echo "Model copied to RAM in $time_taken seconds."
 
 #-------------------------------------------------------
 
+{% if hpc_modules %}
 {% for module in hpc_modules %}
 module load {{ module }}
 {% endfor %}
+echo "All modules loaded..."
+{% endif %}
 echo "All modules loaded..."
 
 source {{ install_path }}/vectoria_env/bin/activate


### PR DESCRIPTION
If the user does not specify any module to load, the Ansible crashes since it was trying to loop over an empty variable.

Added a check that ignores that piece of code if there are no modules in the configuration file. Tested locally, works on my WSL install.

Should fix https://github.com/Eurocc-Italy/Vectoria/issues/24