### PR TITLE
Allow bypass of LLM download during deploy

### DIFF
--- a/ansible/roles/vectoria/tasks/download_LLMs.yml
+++ b/ansible/roles/vectoria/tasks/download_LLMs.yml
@@ -12,6 +12,7 @@
     {% endif %}
     git-lfs install
     git clone git@hf.co:{{ embedder_model }} {{ install_path }}/embedder_model
+  when: embedder_model is defined
 
 - name: Download reranker model
   shell: |
@@ -22,7 +23,7 @@
     {% endif %}
     git-lfs install
     git clone git@hf.co:{{ reranker_model }} {{ install_path }}/reranker_model
-  when: reranker_enabled
+  when: reranker_model is defined and reranker_enabled
 
 - name: Download inference engine
   shell: |
@@ -33,3 +34,4 @@
     {% endif %}
     git-lfs install
     git clone git@hf.co:{{ inference_engine }} {{ install_path }}/inference_engine
+  when: inference_engine is defined


### PR DESCRIPTION
Users can now bypass the automatic download of LLMs by commenting out the corresponding line in the `config.yml` file. This allows the models to be linked/copied from somewhere else already on storage without breaking the deploy stage.