### PR TITLE
fix: clean up existing folders for LLM installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ output
 **/*/__pycache__
 **/*/.ipynb_checkpoints
 
+.venv 
+env/
+venv/
+ENV/
+env_*/
+.ENV/
+
 **/*.pkl
 **/*.faiss
 .idea

--- a/ansible/roles/vectoria/tasks/download_LLMs.yml
+++ b/ansible/roles/vectoria/tasks/download_LLMs.yml
@@ -11,6 +11,7 @@
     {% endfor %}
     {% endif %}
     git-lfs install
+    rm -rf {{ install_path }}/embedder_model
     git clone git@hf.co:{{ embedder_model }} {{ install_path }}/embedder_model
   when: embedder_model is defined
 
@@ -22,6 +23,7 @@
     {% endfor %}
     {% endif %}
     git-lfs install
+    rm -rf {{ install_path }}/reranker_model
     git clone git@hf.co:{{ reranker_model }} {{ install_path }}/reranker_model
   when: reranker_model is defined and reranker_enabled
 
@@ -33,5 +35,6 @@
     {% endfor %}
     {% endif %}
     git-lfs install
+    rm -rf {{ install_path }}/inference_engine
     git clone git@hf.co:{{ inference_engine }} {{ install_path }}/inference_engine
   when: inference_engine is defined


### PR DESCRIPTION
This PR fixes a small bug which breaks the Ansible script when rerunning a second time, and any of the `embedder_model`, `reranker_model`, or `inference_engine` are present, since it tries to clone into an existing directory.

Before (re)downloading, if the folder is present it is removed so it can perform a fresh download.